### PR TITLE
Fix unsafe-eval error

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -1,29 +1,13 @@
-{resolve} = require 'path'
 {BufferedProcess, CompositeDisposable} = require 'atom'
+lsc = require 'atom-livescript'
 
 module.exports =
-  config:
-    lscExecutablePath:
-      default: resolve __dirname, '..', 'node_modules', 'livescript'
-      title: 'lsc Executable path'
-      type: 'string'
-
-  activate: ->
-    @subscriptions = new CompositeDisposable
-    @subscriptions.add atom.config.observe 'linter-lsc.lscExecutablePath',
-      (executablePath)=>
-        @executablePath = executablePath
-
-  deactivate: ->
-    @subscriptions.dispose()
-
   provideLinter: ->
     grammarScopes: ['source.livescript']
     scope: 'file'
     lintOnFly: true
     lint: (textEditor)=>
       new Promise (resolve, reject)=>
-        lsc = require @executablePath
         filePath = textEditor.getPath()
         fileText = textEditor.getText()
         try
@@ -43,7 +27,7 @@ module.exports =
           resolve messages
 
         process.onWillThrowError ({error, handle})=>
-          atom.notifications.addError "Failed to run #{@lscExecutablePath}",
+          atom.notifications.addError "Failed to run lsc",
             detail: error.message
             dismissable: true
           handle()

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "livescript": "^1.4.0"
+    "atom-livescript": "0.0.1"
   },
   "providedServices": {
     "linter": {


### PR DESCRIPTION
Hi,

I met below error.

```
Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self'".
```

LiveScript using `Function` (https://github.com/gkz/LiveScript/blob/master/src/ast.ls#L1042) and it can evade with `loophole` module.

So I published `atom-livescript` package to npm and this using `loophole`.

Thanks

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-lsc/7)
<!-- Reviewable:end -->
