### PR TITLE
Fix for another parse error

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -14,14 +14,22 @@ module.exports =
           lsc.compile fileText
           resolve []
         catch err
-          result = /Parse error on line (\d+): (.*)/.exec err.message
+          result = switch
+            when err instanceof SyntaxError
+              r = /(.*) on line (\d+)$/.exec err.message
+              line: r[2]
+              text: r[1]
+            else
+              r = /Parse error on line (\d+): (.*)/.exec err.message
+              line: r[1]
+              text: r[2]
           messages = [
             type: 'Error'
-            text: result[2]
+            text: result.text
             filePath: filePath
             range: [
-              [parseInt(result[1])-1, 0]
-              [parseInt(result[1]), 0]
+              [parseInt(result.line)-1, 0]
+              [parseInt(result.line), 0]
             ]
           ]
           resolve messages


### PR DESCRIPTION
LiveScript throws another type of error message like this

```
empty export on line 1
```

This message can not match `/Parse error on line (\d+): (.*)/`. So I added new RegExp.

Thanks

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-lsc/8)
<!-- Reviewable:end -->
