### PR TITLE
Remove Unicode variable from good test

### DIFF
--- a/spec/fixtures/good.ls
+++ b/spec/fixtures/good.ls
@@ -22,6 +22,3 @@ up-case-name = (.name .= to-upper-case!)
 [{id:id1, name, age} for {id:id1, name} in table1
                      for {id:id2, age} in table2
                      when id1 is id2]
-
-# Unicode variables
-Ω = 'blah'


### PR DESCRIPTION
It turns out that although Windows has no problem with that character, on Linux it throws an issue. This is likely a bug in lsc, but as removing it doesn't really change the purpose of the good.ls file the simplest thing is to just remove it here.